### PR TITLE
Change to any other screen

### DIFF
--- a/src/ewmh_m2m/__main__.py
+++ b/src/ewmh_m2m/__main__.py
@@ -35,15 +35,20 @@ def move_to_screen(args):
     new_screen = get_sibling_screen(
         get_sibling_screens(containing_screen, screens),
         args.direction, args.no_wrap)
-    if not new_screen:
-        _logger.fatal("No sibling screen found")
-    else:
-        new_window_geometry = relative_geometry.build_absolute(new_screen)
-        _logger.debug("New window geometry: %s", new_window_geometry)
-        window.geometry = new_window_geometry
-    window.maximized = window_maximized_state
-    window.fullscreen = window_fullscreen_state
-    window.conn.flush()
+    try:
+        if not new_screen:
+            raise ValueError("No sibling screen found")
+        else:
+            new_window_geometry = relative_geometry.build_absolute(new_screen)
+            _logger.debug("New window geometry: %s", new_window_geometry)
+            window.geometry = new_window_geometry
+    except ValueError as e:
+        _logger.fatal(e)
+        raise
+    finally:
+        window.maximized = window_maximized_state
+        window.fullscreen = window_fullscreen_state
+        window.conn.flush()
 
 
 def setup_log(args):


### PR DESCRIPTION
Hey !

This PR comes with 2 simple changes :

1. exit with status=1 if no sibling found
   this allows to chain, e.g.:
   ```shell
   move-to-window -d SOUTH || move-to-window -d EAST
   ```
2. by default (without a `--direction` parameter), does the equivalent of:
   ```shell
   move-to-window -d EAST || move-to-window -d SOUTH
   ```

My use case is that I have 2 screens, sometimes left-right, sometimes up-down (depending on which desk I'm working on). So I needed a command to just switch between the 2 screens, whatever their arrangement. Each of these two changes allow doing that.

And thanks for this nice tool. Very helpful !