### PR TITLE
Replaced deprecated pkg_resources API with importlib.metadata

### DIFF
--- a/src/ewmh_m2m/__init__.py
+++ b/src/ewmh_m2m/__init__.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-from pkg_resources import get_distribution, DistributionNotFound
+import importlib.metadata
 
 try:
     # Change here if project is renamed and does not equal the package name
-    dist_name = __name__
-    __version__ = get_distribution(dist_name).version
-except DistributionNotFound:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
     __version__ = 'unknown'
 finally:
-    del get_distribution, DistributionNotFound
+    del importlib.metadata


### PR DESCRIPTION
closes Issue https://github.com/AlexisBRENON/ewmh_m2m/issues/28

The deprecated package ``pkg_resources`` was replaced with ``importlib.metadata``